### PR TITLE
Add support for AI voice options

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@
 A simple progressive web app that reads text files or pasted text aloud, like a lightweight Audible.
 
 ## Features
-- Pick from available voices on your device (Web Speech API).
+- Pick from available voices on your device (Web Speech API) or extra AI voices.
 - Control speed, pitch, and chunk size.
 - Upload `.txt`, `.md`, or `.html` files.
 - Save progress between sessions.
 - Installable as a PWA; works offline after first load.
+- Additional AI voice options can be added by editing `ai-voices.json`. Playback uses a placeholder API endpoint; replace it with your TTS service.
 
 ## Running Locally
 ```bash

--- a/ai-voices.json
+++ b/ai-voices.json
@@ -1,0 +1,4 @@
+[
+  { "id": "alloy", "name": "Alloy", "lang": "en-US" },
+  { "id": "verse", "name": "Verse", "lang": "en-GB" }
+]


### PR DESCRIPTION
## Summary
- load extra AI voices from `ai-voices.json`
- attempt to play AI voices via a placeholder external TTS API
- document how to configure AI voices

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_689aa2e5373083249358cceced517f73