### PR TITLE
Add OpenAI TTS support for AI voices

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple progressive web app that reads text files or pasted text aloud, like a 
 - Upload `.txt`, `.md`, or `.html` files.
 - Save progress between sessions.
 - Installable as a PWA; works offline after first load.
-- Additional AI voice options can be added by editing `ai-voices.json`. Playback uses a placeholder API endpoint; replace it with your TTS service.
+- Additional AI voice options can be added by editing `ai-voices.json`. Built-in support uses [OpenAI's text-to-speech](https://api.openai.com/) (`gpt-4o-mini-tts`). You'll be prompted for an API key the first time you pick an AI voice; the key is stored locally.
 
 ## Running Locally
 ```bash


### PR DESCRIPTION
## Summary
- Use OpenAI `gpt-4o-mini-tts` to synthesize selected AI voices
- Prompt for and locally store the API key when an AI voice is used
- Document OpenAI TTS support in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689aa76a6b5883248dd57ebf43c14576