### PR TITLE
Add interface for recording custom AI voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A simple progressive web app that reads text files or pasted text aloud, like a 
 
 ## Features
 - Pick from available voices on your device (Web Speech API) or extra AI voices.
+- Record your own voice and train a custom AI voice.
 - Control speed, pitch, and chunk size.
 - Upload `.txt`, `.md`, or `.html` files.
 - Save progress between sessions.

--- a/index.html
+++ b/index.html
@@ -24,6 +24,11 @@
         <select id="voiceSelect" aria-label="Voice selector"></select>
       </div>
       <div class="row">
+        <button id="recordVoiceBtn">🎤 Record My Voice</button>
+        <button id="stopRecordBtn" hidden>⏹️ Stop</button>
+        <button id="trainVoiceBtn" class="ghost" hidden>Train Voice</button>
+      </div>
+      <div class="row">
         <label for="rate">Speed <span id="rateVal">1.0</span>x</label>
         <input id="rate" type="range" min="0.5" max="2" value="1" step="0.05">
       </div>


### PR DESCRIPTION
## Summary
- add buttons to record and train a custom AI voice
- support capturing audio, uploading to API and selecting custom voice
- document custom voice feature in README

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_689aab64a4208324b0a4e7640a4fc54a